### PR TITLE
Syntax highlight on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,18 @@ LinkedIn uses the OAuth 1.0a flow, you can read about it here: https://developer
 
 Usage is as per any other OmniAuth 1.0 strategy. So let's say you're using Rails, you need to add the strategy to your `Gemfile` along side omniauth:
 
-    gem 'omniauth'
-    gem 'omniauth-linkedin'
+```ruby
+gem 'omniauth'
+gem 'omniauth-linkedin'
+```
 
 Once these are in, you need to add the following to your `config/initializers/omniauth.rb`:
 
-    Rails.application.config.middleware.use OmniAuth::Builder do
-      provider :linkedin, "consumer_key", "consumer_secret"
-    end
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :linkedin, "consumer_key", "consumer_secret"
+end
+```
 
 You will obviously have to put in your key and secret, which you get when you register your app with LinkedIn (they call them API Key and Secret Key).
 
@@ -27,27 +31,35 @@ LinkedIn recently (August 2012) provided the ability to request different permis
 
 By default, omniauth-linkedin requests the following permissions:
 
-    "r_basicprofile r_emailaddress"
+```ruby
+"r_basicprofile r_emailaddress"
+```
 
 This allows us to obtain enough information from LinkedIn to satisfy the requirements for the basic auth hash schema.
 
 To change the scope, simply change your initializer to something like this:
 
-    Rails.application.config.middleware.use OmniAuth::Builder do
-      provider :linkedin, "consumer_key", "consumer_secret", :scope => 'r_fullprofile r_emailaddress r_network'
-    end
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :linkedin, "consumer_key", "consumer_secret", :scope => 'r_fullprofile r_emailaddress r_network'
+end
+```
 
 One thing to note is the fact that when you ask for extra permissions, you will probably want to specify the array of fields that you want returned in the omniauth hash. If you don't then only the default fields (see below) will be returned which would defeat the purpose of asking for the extra permissions. So do the following:
 
-    Rails.application.config.middleware.use OmniAuth::Builder do
-      provider :linkedin, "consumer_key", "consumer_secret", :scope => 'r_fullprofile r_emailaddress r_network', :fields => ["id", "email-address", "first-name", "last-name", "headline", "industry", "picture-url", "public-profile-url", "location", "connections"]
-    end
+```ruby
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :linkedin, "consumer_key", "consumer_secret", :scope => 'r_fullprofile r_emailaddress r_network', :fields => ["id", "email-address", "first-name", "last-name", "headline", "industry", "picture-url", "public-profile-url", "location", "connections"]
+end
+```
 
 We have to repeat the list of default fields in order to get the extra 'connections' field.
 
 The list of default fields is as follows:
 
-    ["id", "email-address", "first-name", "last-name", "headline", "industry", "picture-url", "public-profile-url", "location"]
+```ruby
+["id", "email-address", "first-name", "last-name", "headline", "industry", "picture-url", "public-profile-url", "location"]
+```
 
 To see a complete list of available fields, consult the LinkedIn documentation at https://developer.linkedin.com/documents/profile-fields
 
@@ -57,20 +69,26 @@ You may find that you want to use OmniAuth for authentication, but you want to u
 
 Configure the LinkedIn gem with your consumer key and secret:
 
-    LinkedIn.configure do |config|
-      config.token = "consumer_key"
-      config.secret = "consumer_secret"
-    end
+```ruby
+LinkedIn.configure do |config|
+  config.token = "consumer_key"
+  config.secret = "consumer_secret"
+end
+```
 
 Use OmniAuth as per normal to obtain an access token and an access token secret for your user. Now create the LinkedIn client and authorize it using the access token and secret that you ontained via OmniAuth:
 
-    client = LinkedIn::Client.new
-    client.authorize_from_access("access_token", "access_token_secret")
+```ruby
+client = LinkedIn::Client.new
+client.authorize_from_access("access_token", "access_token_secret")
+```
 
 You can now make API calls as per normal e.g.:
 
-    client.profile
-    client.add_share({:comment => "blah"})
+```ruby
+client.profile
+client.add_share({:comment => "blah"})
+```
 
 ## Note on Patches/Pull Requests
 


### PR DESCRIPTION
``` ruby
gem 'omniauth'
gem 'omniauth-linkedin'
```

is better than

```
 gem 'omniauth'
 gem 'omniauth-linkedin'
```

Any problem using the Github flavored Markdown?
